### PR TITLE
Assure the influxdb_configuration_dir path exists before trying to write configuration file to it

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -1,4 +1,9 @@
 ---
+- name: Set configuration directory path
+  file:
+    path: "{{ influxdb_configuration_dir }}"
+    state: directory
+
 - name: Set templatized InfluxDB configuration
   template: 
     src: influxdb.conf.j2 


### PR DESCRIPTION
Using this role in a playbook where inflluxdb_configuration_dir was being set to an alternative path, an error was thrown because it wasn't created before trying to write the influxdb configuration file to it. This PR addresses that by creating the directory path if it doesn't exist already. 
