### PR TITLE
optionally install python client

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -17,6 +17,10 @@ influxdb_load_sample_data: no
 influxdb_sample_database_name: sample_database
 influxdb_sample_measurement_name: random_ints
 
+influxdb_bind_hostname: "{{ ansible_hostname }}"
+
+influxdb_install_python_client: no
+
 # NOTE: Since Ansible uses Python on the backend, all boolean values are capitalized when being
 # rendered (which is not valid TOML). To get around this, make sure you quote any boolean values
 # (true -> "true") to ensure correct formatting (for template variables).

--- a/tasks/install-debian.yml
+++ b/tasks/install-debian.yml
@@ -10,6 +10,16 @@
     - python-apt
     - curl
     - apt-transport-https
+    
+- name: Install any necessary PIP dependencies [Debian/Ubuntu]
+  apt: 
+    name: "{{ item }}" 
+    state: present 
+    update_cache: yes 
+    cache_valid_time: 3600
+  with_items:
+    - python-pip
+  when: influxdb_install_python_client
 
 - name: Import InfluxData GPG signing key [Debian/Ubuntu]
   apt_key:

--- a/tasks/install-redhat.yml
+++ b/tasks/install-redhat.yml
@@ -6,6 +6,14 @@
   with_items:
     - curl
 
+- name: Install any necessary PIP dependencies [RedHat/CentOS]
+  yum: 
+    name: "{{ item }}" 
+    state: present
+  with_items:
+    - python-pip
+  when: influxdb_install_python_client
+
 - name: Add InfluxData repository file [RHEL/CentOS]
   template:
     src: etc/yum.repos.d/influxdata.repo.j2

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -16,6 +16,13 @@
 - include: install-debian.yml
   when: ansible_os_family == "Debian"
 
+- name: Install InfluxDB python client package [PIP]
+  pip: >
+    name=influxdb
+    state={{ influxdb_python_client_state | default(omit) }}
+    version={{ influxdb_python_client_version | default(omit) }}
+  when: influxdb_install_python_client
+
 - name: Capture InfluxDB version information
   command: influxd version
   register: influxdb_runtime_version_raw

--- a/templates/influxdb.conf.j2
+++ b/templates/influxdb.conf.j2
@@ -18,8 +18,8 @@ reporting-disabled = {{ influxdb_disable_reporting }}
 [meta]
   enabled = {{ influxdb_meta_enabled }}
   dir = "{{ influxdb_meta_dir }}"
-  bind-address = "{{ ansible_hostname }}:{{ influxdb_meta_port }}"
-  http-bind-address = "{{ ansible_hostname }}:{{ influxdb_meta_http_port }}"
+  bind-address = "{{ influxdb_bind_hostname }}:{{ influxdb_meta_port }}"
+  http-bind-address = "{{ influxdb_bind_hostname }}:{{ influxdb_meta_http_port }}"
   retention-autocreate = {{ influxdb_meta_retention_autocreate }}
   election-timeout = "{{ influxdb_meta_election_timeout }}"
   heartbeat-timeout = "{{ influxdb_meta_heartbeat_timeout }}"
@@ -118,7 +118,7 @@ reporting-disabled = {{ influxdb_disable_reporting }}
 
 [admin]
   enabled = {{ influxdb_admin_enabled }}
-  bind-address = "{{ ansible_hostname }}:{{ influxdb_admin_port }}"
+  bind-address = "{{ influxdb_bind_hostname }}:{{ influxdb_admin_port }}"
   https-enabled = {{ influxdb_admin_https_enabled }}
   https-certificate = "{{ influxdb_admin_https_certificate }}"
 
@@ -139,7 +139,7 @@ reporting-disabled = {{ influxdb_disable_reporting }}
 
 [http]
   enabled = {{ influxdb_http_enabled }}
-  bind-address = "{{ ansible_hostname }}:{{ influxdb_http_port }}"
+  bind-address = "{{ influxdb_bind_hostname }}:{{ influxdb_http_port }}"
   auth-enabled = {{ influxdb_http_auth_enabled }}
   log-enabled = {{ influxdb_http_log_enabled }}
   write-tracing = {{ influxdb_http_write_tracing }}
@@ -190,12 +190,20 @@ reporting-disabled = {{ influxdb_disable_reporting }}
   # ignore-unnamed = {{ influxdb_graphite_ignore_unnamed }}
 
 ###
+{% if influxdb_runtime_version | version_compare('0.11', '<') %}
 ### [[collectd]]
+{% else %}
+### [collectd]
+{% endif %}
 ###
 ### Controls the listener for collectd data.
 ###
 
+{% if influxdb_runtime_version | version_compare('0.11', '<') %}
 [[collectd]]
+{% else %}
+[collectd]
+{% endif %}
   enabled = {{ influxdb_collectd_enabled }}
   bind-address = ":{{ influxdb_collectd_port }}"
   database = "{{ influxdb_collectd_database }}"
@@ -206,12 +214,20 @@ reporting-disabled = {{ influxdb_disable_reporting }}
   typesdb = "{{ influxdb_collectd_typesdb }}"
 
 ###
+{% if influxdb_runtime_version | version_compare('0.11', '<') %}
 ### [[opentsdb]]
+{% else %}
+### [opentsdb]
+{% endif %}
 ###
 ### Controls the listener for OpenTSDB data.
 ###
 
+{% if influxdb_runtime_version | version_compare('0.11', '<') %}
 [[opentsdb]]
+{% else %}
+[opentsdb]
+{% endif %}
   enabled = {{ influxdb_opentsdb_enabled }}
   # bind-address = ":{{ influxdb_opentsdb_port }}"
   # database = "{{ influxdb_opentsdb_database }}"


### PR DESCRIPTION
having that allowed me to use:

https://github.com/ansible/ansible-modules-extras/tree/devel/database/influxdb

to manage dbs and retention. also:
- add `influxdb_bind_hostname` var (defaults to `{{ ansible_hostname }}` ) and
- deal w/ config format changes

for this last one i ran into errors like w/ `0.12.2`:

```
run: parse config: Type mismatch for 'run.Config.collectd': Type mismatch for collectd.Config. Expected map but found '[]map[string]interface {}'.
```

 and saw this https://github.com/influxdata/influxdb/issues/3615. i'm not sure when that changed but i've set the version check to be `0.11`.
