### PR TITLE
disable chunking enforcement

### DIFF
--- a/templates/influxdb.conf.j2
+++ b/templates/influxdb.conf.j2
@@ -146,7 +146,8 @@ reporting-disabled = {{ influxdb_disable_reporting }}
   pprof-enabled = {{ influxdb_http_pprof_enabled }}
   https-enabled = {{ influxdb_http_https_enabled }}
   https-certificate = "{{ influxdb_http_https_certificate }}"
-  
+  max-row-limit = 0
+
 ###
 ### [[graphite]]
 ###


### PR DESCRIPTION
As of 1.2 chunking is enforced following the `max-row-limit` option. We are aiming to disable it for the testing framework.

@rossmcdonald 