### PR TITLE
Fixed issue with new Influx version numbering

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -18,6 +18,6 @@
 
 - name: Capture InfluxDB version, branch, and commit
   set_fact:
-    influxdb_runtime_version: "{{ influxdb_runtime_version_raw.stdout.split()[1] }}"
+    influxdb_runtime_version: "{{ influxdb_runtime_version_raw.stdout.split()[1].replace('v','') }}"
     influxdb_runtime_branch: "{{ influxdb_runtime_version_raw.stdout.split()[3] }}"
     influxdb_runtime_commit: "{{ influxdb_runtime_version_raw.stdout.split()[4] }}"


### PR DESCRIPTION
Influx now include a prefixed `v` in their versioning which throws out the `influxdb_runtime_version` fact resolution.

This change should resolve the problem without causing problems for the old versioning scheme. 

Tested using `puppetlabs/centos-6.6-64-nocm` and `bento/centos-7.3` boxes