### PR TITLE
Added missing https certificate key to influxdb.conf

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ venv/
 *rpm
 scratch/
 .bundle/
+.idea/

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -93,6 +93,7 @@ influxdb_http_write_tracing: "false"
 influxdb_http_pprof_enabled: "false"
 influxdb_http_https_enabled: "false"
 influxdb_http_https_certificate: /etc/ssl/influxdb.pem
+influxdb_http_https_certificate_key: /etc/ssl/influxdb_key.pem
 
 ## Graphite Settings
 influxdb_graphite_enabled: "false"

--- a/templates/influxdb.conf.j2
+++ b/templates/influxdb.conf.j2
@@ -146,6 +146,7 @@ reporting-disabled = {{ influxdb_disable_reporting }}
   pprof-enabled = {{ influxdb_http_pprof_enabled }}
   https-enabled = {{ influxdb_http_https_enabled }}
   https-certificate = "{{ influxdb_http_https_certificate }}"
+  https-private-key= "{{ influxdb_http_https_certificate_key }}"
   
 ###
 ### [[graphite]]


### PR DESCRIPTION
Hi Ross.

Influxdb version 1.7.4 requires both ssl certificate and certificate key to be provided in configuration file


[documentation](https://docs.influxdata.com/influxdb/v1.7/administration/https_setup/)
```
[http]

  [...]

  # Determines whether HTTPS is enabled.
  https-enabled = true

  [...]

  # The SSL certificate to use when HTTPS is enabled.
  https-certificate = "<bundled-certificate-file>.pem"

  # Use a separate private key location.
  https-private-key = "<bundled-certificate-file>.pem"
```