### PR TITLE
Fix RedHat repo url

### DIFF
--- a/templates/etc/yum.repos.d/influxdata.repo.j2
+++ b/templates/etc/yum.repos.d/influxdata.repo.j2
@@ -1,6 +1,10 @@
 [influxdb]
 name = InfluxDB Repository - {{ ansible_distribution }} $releasever
+{% if ansible_distribution == "RedHat" %}
+baseurl = https://repos.influxdata.com/rhel/$releasever/$basearch/{{ influxdb_install_version }}
+{% else %}
 baseurl = https://repos.influxdata.com/{{ ansible_distribution|lower }}/$releasever/$basearch/{{ influxdb_install_version }}
+{% endif %}
 enabled = 1
 gpgcheck = 1
 gpgkey = https://repos.influxdata.com/influxdb.key


### PR DESCRIPTION
The RedHat repo is in the `/rhel` path, not `/redhat` at this point:

https://repos.influxdata.com/

![image](https://user-images.githubusercontent.com/795289/57392351-d1430280-71c0-11e9-80bf-d9a0ff941b43.png)

This PR adds uses the correct path for systems with "RedHat" `ansible_distribution`.