### PR TITLE
Replace deprecated in 2.5 `version_compare` with `is version`

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
   description: Install and configure InfluxDB, a time-series database
   company: InfluxData
   license: MIT
-  min_ansible_version: 1.2
+  min_ansible_version: 2.5
   platforms:
     - name: EL
       versions:

--- a/templates/influxdb.conf.j2
+++ b/templates/influxdb.conf.j2
@@ -191,7 +191,7 @@ reporting-disabled = {{ influxdb_disable_reporting }}
   # ignore-unnamed = {{ influxdb_graphite_ignore_unnamed }}
 
 ###
-{% if influxdb_runtime_version | version_compare('0.11', '>') %}
+{% if influxdb_runtime_version is version('0.11', '>') %}
 ### [[collectd]]
 {% else %}
 ### [collectd]
@@ -200,7 +200,7 @@ reporting-disabled = {{ influxdb_disable_reporting }}
 ### Controls the listener for collectd data.
 ###
 
-{% if influxdb_runtime_version | version_compare('0.11', '>') %}
+{% if influxdb_runtime_version is version('0.11', '>') %}
 [[collectd]]
 {% else %}
 [collectd]
@@ -215,7 +215,7 @@ reporting-disabled = {{ influxdb_disable_reporting }}
   typesdb = "{{ influxdb_collectd_typesdb }}"
 
 ###
-{% if influxdb_runtime_version | version_compare('0.11', '>') %}
+{% if influxdb_runtime_version is version('0.11', '>') %}
 ### [[opentsdb]]
 {% else %}
 ### [opentsdb]
@@ -224,7 +224,7 @@ reporting-disabled = {{ influxdb_disable_reporting }}
 ### Controls the listener for OpenTSDB data.
 ###
 
-{% if influxdb_runtime_version | version_compare('0.11', '>') %}
+{% if influxdb_runtime_version is version('0.11', '>') %}
 [[opentsdb]]
 {% else %}
 [opentsdb]


### PR DESCRIPTION
The role fails with Ansible 2.9 because version_compare was scheduled for removal in 2.5 and finally removed.