### PR TITLE
Allow running in check mode

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -18,6 +18,7 @@
 - name: Capture InfluxDB version information
   command: influxd version
   register: influxdb_runtime_version_raw
+  check_mode: false
 
 - name: Capture InfluxDB version, branch, and commit
   set_fact:


### PR DESCRIPTION
The `command` module doesn't run automatically when running `ansible` in `--check` mode. This results in the `influxdb_runtime_version_raw` not being set and breaking when `set_fact` is called in the next task. You get the following error:

```
The task includes an option with an undefined variable. The error was: 'dict object' has no attribute 'stdout'
  
The error appears to be in '/var/lib/builds/infrastructure/auto/galaxy-roles/influxdb/tasks/install.yml': line 22, column 3, but may
be elsewhere in the file depending on the exact syntax problem.
  
The offending line appears to be:
  
  
- name: Capture InfluxDB version, branch, and commit
  ^ here
```

The following change fixes this behavior by explicitly setting the `command` module to run in check mode.