### PR TITLE
Add templates option to graphite settings

### DIFF
--- a/templates/influxdb.conf.j2
+++ b/templates/influxdb.conf.j2
@@ -190,6 +190,14 @@ reporting-disabled = {{ influxdb_disable_reporting }}
   ## Otherwise an error will be logged and the metric rejected.
   # ignore-unnamed = {{ influxdb_graphite_ignore_unnamed }}
 
+{% if influxdb_graphite_templates %}
+  templates = [
+{% for template in influxdb_graphite_templates %}
+    "{{ template }}",
+{% endfor %}
+  ]
+{% endif %}
+
 ###
 {% if influxdb_runtime_version is version('0.11', '>') %}
 ### [[collectd]]


### PR DESCRIPTION
Add the option to configure `graphite.templates`. I also noticed setting any of the other `influxdb_graphite_*` doesn't actually work because it is commented out in the actual template. The only one that works is `influxdb_graphite_enabled`. However I will address that in another MR.