### PR TITLE
refactor package install to be compatible with ansible > 2.11

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -3,6 +3,7 @@ galaxy_info:
   author: Ross McDonald
   description: Install and configure InfluxDB, a time-series database
   company: InfluxData
+  role_name: influxdb
   license: MIT
   min_ansible_version: 2.5
   platforms:
@@ -12,6 +13,8 @@ galaxy_info:
         - 7
     - name: Ubuntu
       versions:
+        - bionic
+        - focal
         - trusty
         - utopic
         - vivid

--- a/tasks/install-debian.yml
+++ b/tasks/install-debian.yml
@@ -1,24 +1,21 @@
 ---
 - name: Install any necessary dependencies [Debian/Ubuntu]
   apt: 
-    name: "{{ item }}" 
+    name:
+      - python-httplib2
+      - python-apt
+      - curl
+      - apt-transport-https
     state: present 
     update_cache: yes 
     cache_valid_time: 3600
-  with_items:
-    - python-httplib2
-    - python-apt
-    - curl
-    - apt-transport-https
     
 - name: Install any necessary PIP dependencies [Debian/Ubuntu]
   apt: 
-    name: "{{ item }}" 
+    name: python-pip
     state: present 
     update_cache: yes 
     cache_valid_time: 3600
-  with_items:
-    - python-pip
   when: influxdb_install_python_client
 
 - name: Import InfluxData GPG signing key [Debian/Ubuntu]

--- a/tasks/install-fedora.yml
+++ b/tasks/install-fedora.yml
@@ -1,17 +1,13 @@
 ---
 - name: Install any necessary dependencies [RedHat/Fedora]
   dnf: 
-    name: "{{ item }}" 
+    name: curl
     state: present
-  with_items:
-    - curl
 
 - name: Install any necessary PIP dependencies [RedHat/Fedora]
   dnf: 
-    name: "{{ item }}" 
+    name: python-pip
     state: present
-  with_items:
-    - python-pip
   when: influxdb_install_python_client
 
 - name: Add InfluxData repository file [RHEL/Fedora]

--- a/tasks/install-redhat.yml
+++ b/tasks/install-redhat.yml
@@ -1,17 +1,13 @@
 ---
 - name: Install any necessary dependencies [RedHat/CentOS]
   yum: 
-    name: "{{ item }}" 
+    name: curl
     state: present
-  with_items:
-    - curl
 
 - name: Install any necessary PIP dependencies [RedHat/CentOS]
   yum: 
-    name: "{{ item }}" 
+    name: python-pip
     state: present
-  with_items:
-    - python-pip
   when: influxdb_install_python_client
 
 - name: Add InfluxData repository file [RHEL/CentOS]


### PR DESCRIPTION
ansible.builtin.apt supports an array of packages for installation. Looping over packages is deprecated.
See last point of these notes: https://docs.ansible.com/ansible/latest/collections/ansible/builtin/apt_module.html#notes 
