### PR TITLE
Support for Flux and InfluxDB2

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,6 +2,9 @@
 # Channel of InfluxDB to install (stable, unstable, nightly)
 influxdb_install_version: stable
 
+# InfluxDB package to install (influxdb, influxdb2)
+influxdb_install_package: influxdb
+
 # If multiple servers are specified, whether to create a clustered configuration
 # NOTE:
 #   - Do not attempt to cluster previously-unclustered servers. This can lead to data loss.
@@ -93,6 +96,7 @@ influxdb_http_log_enabled: "true"
 influxdb_http_write_tracing: "false"
 influxdb_http_pprof_enabled: "false"
 influxdb_http_https_enabled: "false"
+influxdb_http_flux_enabled: "false"
 influxdb_http_https_certificate: /etc/ssl/influxdb.pem
 influxdb_http_https_certificate_key: /etc/ssl/influxdb_key.pem
 

--- a/tasks/install-debian.yml
+++ b/tasks/install-debian.yml
@@ -34,7 +34,7 @@
 
 - name: Install InfluxDB packages [Debian/Ubuntu]
   apt: 
-    name: influxdb
+    name: "{{ influxdb_install_package }}"
     state: latest
     update_cache: yes
     cache_valid_time: 3600

--- a/tasks/install-fedora.yml
+++ b/tasks/install-fedora.yml
@@ -20,7 +20,7 @@
 
 - name: Install InfluxDB packages [RHEL/Fedora]
   dnf: 
-    name: influxdb
+    name: "{{ influxdb_install_package }}"
     state: present
   when: influxdb_install_url is not defined or influxdb_install_url == None
 

--- a/tasks/install-redhat.yml
+++ b/tasks/install-redhat.yml
@@ -20,7 +20,7 @@
 
 - name: Install InfluxDB packages [RHEL/CentOS]
   yum: 
-    name: influxdb
+    name: "{{ influxdb_install_package }}"
     state: latest
   when: influxdb_install_url is not defined or influxdb_install_url == None
 

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -1,11 +1,11 @@
 ---
-- include: install-redhat.yml
+- include_tasks: install-redhat.yml
   when: ansible_os_family == "RedHat" and ansible_distribution != "Fedora"
 
-- include: install-fedora.yml
+- include_tasks: install-fedora.yml
   when: ansible_os_family == "RedHat" and ansible_distribution == "Fedora"
 
-- include: install-debian.yml
+- include_tasks: install-debian.yml
   when: ansible_os_family == "Debian"
 
 - name: Install InfluxDB python client package [PIP]

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,8 +1,8 @@
 ---
-- include: install.yml
+- include_tasks: install.yml
   tags: [influxdb, install]
 
-- include: configure.yml
+- include_tasks: configure.yml
   tags: [influxdb, configure]
 
 - name: Start the InfluxDB service
@@ -39,12 +39,12 @@
       - "influxdb_start_attempt == 0"
   when: influxdb_started.changed and influxdb_start_service and influxdb_start_attempt.failed is defined and influxdb_start_attempt.failed == True
 
-- include: demo.yml
+- include_tasks: demo.yml
   tags: [influxdb, demo]
   when: influxdb_load_sample_data and influxdb_http_auth_enabled == "false" and influxdb_start_service
 
-- include: verify.yml
+- include_tasks: verify.yml
   tags: [influxdb, verify]
 
-- include: stress.yml
+- include_tasks: stress.yml
   tags: [influxdb, stress]

--- a/templates/influxdb.conf.j2
+++ b/templates/influxdb.conf.j2
@@ -145,6 +145,7 @@ reporting-disabled = {{ influxdb_disable_reporting }}
   write-tracing = {{ influxdb_http_write_tracing }}
   pprof-enabled = {{ influxdb_http_pprof_enabled }}
   https-enabled = {{ influxdb_http_https_enabled }}
+  flux-enabled = {{ influxdb_http_flux_enabled }}
   https-certificate = "{{ influxdb_http_https_certificate }}"
   https-private-key= "{{ influxdb_http_https_certificate_key }}"
   


### PR DESCRIPTION
1. Added support for enabling Flux (which is disabled by default).
2. Added support for installing InfluxDB2 by setting the influxdb_install_package to influxdb2 instead of the default of influxdb.